### PR TITLE
회원가입 - IP주소 필수 및 중복 검사, 유효성 검사

### DIFF
--- a/src/main/java/com/crosscert/firewall/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/crosscert/firewall/config/security/WebSecurityConfig.java
@@ -27,6 +27,7 @@ public class WebSecurityConfig {
     @Profile("prod")
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         log.info("운영용 Spring Security 설정");
+        //TODO : 유저 관리는 LEADER 권한만 가능하도록 설정 수정하기
         return httpSecurity
                 .cors().disable()
                 .csrf().disable()

--- a/src/main/java/com/crosscert/firewall/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/crosscert/firewall/config/security/WebSecurityConfig.java
@@ -36,7 +36,7 @@ public class WebSecurityConfig {
                     .antMatchers("/css/**").permitAll()
                     .antMatchers("/js/**").permitAll()
                     .antMatchers("/").permitAll()           //홈화면
-                    .antMatchers("/signup").anonymous()     //회원가입
+                    .antMatchers("/signup/**").anonymous()     //회원가입
                     .antMatchers("/login").anonymous()      //로그인
 //                    .antMatchers("/leader/**").hasRole("LEADER")
                 .anyRequest().authenticated() //그 외 로그인 필요
@@ -65,7 +65,7 @@ public class WebSecurityConfig {
                 .antMatchers("/css/**").permitAll()
                 .antMatchers("/js/**").permitAll()
                 .antMatchers("/").permitAll()           //홈화면
-                .antMatchers("/signup").anonymous()     //회원가입
+                .antMatchers("/signup/**").anonymous()     //회원가입
                 .antMatchers("/login").anonymous()      //로그인
                 .anyRequest().permitAll() //개발용 임시 모두허용
                 .and()

--- a/src/main/java/com/crosscert/firewall/controller/LoginController.java
+++ b/src/main/java/com/crosscert/firewall/controller/LoginController.java
@@ -48,7 +48,7 @@ public class LoginController {
 
 
     //이메일 중복체크
-    @GetMapping("/checkDuplicateEmail")
+    @GetMapping("/signup/checkDuplicateEmail")
     @ResponseBody
     public ResponseEntity<Object> checkDuplicateEmail(@RequestParam("email") String email) {
         log.info("{}.checkDuplicateEmail",this.getClass());
@@ -58,7 +58,7 @@ public class LoginController {
     }
 
     //IP주소 중복체크
-    @GetMapping("/checkDuplicateIpAddress")
+    @GetMapping("/signup/checkDuplicateIpAddress")
     @ResponseBody
     public ResponseEntity<Object> checkDuplicateIpAddress(@RequestParam("ipAddress") String ipAddress) {
         log.info("{}.checkDuplicateIpAddress",this.getClass());

--- a/src/main/java/com/crosscert/firewall/controller/LoginController.java
+++ b/src/main/java/com/crosscert/firewall/controller/LoginController.java
@@ -1,6 +1,9 @@
 package com.crosscert.firewall.controller;
 
 import com.crosscert.firewall.dto.MemberDTO;
+import com.crosscert.firewall.entity.IP;
+import com.crosscert.firewall.entity.IpAddress;
+import com.crosscert.firewall.service.IPService;
 import com.crosscert.firewall.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -20,6 +23,7 @@ import java.util.Map;
 public class LoginController {
 
     private final MemberService memberService;
+    private final IPService ipService;
 
     //로그인 페이지
     @GetMapping("/login")
@@ -42,6 +46,7 @@ public class LoginController {
         return "redirect:/login";
     }
 
+
     //이메일 중복체크
     @GetMapping("/checkDuplicateEmail")
     @ResponseBody
@@ -49,6 +54,16 @@ public class LoginController {
         log.info("{}.checkDuplicateEmail",this.getClass());
         Map<String, Object> data = new HashMap<>();
         data.put("result", memberService.isPresentMember(email));
+        return ResponseEntity.ok(data);
+    }
+
+    //IP주소 중복체크
+    @GetMapping("/checkDuplicateIpAddress")
+    @ResponseBody
+    public ResponseEntity<Object> checkDuplicateIpAddress(@RequestParam("ipAddress") String ipAddress) {
+        log.info("{}.checkDuplicateIpAddress",this.getClass());
+        Map<String, Object> data = new HashMap<>();
+        data.put("result", ipService.isPresentIp(new IpAddress(ipAddress)));
         return ResponseEntity.ok(data);
     }
 

--- a/src/main/java/com/crosscert/firewall/repository/IPRepository.java
+++ b/src/main/java/com/crosscert/firewall/repository/IPRepository.java
@@ -11,4 +11,5 @@ public interface IPRepository extends JpaRepository<IP, Long> {
 
     Optional<IP> findByAddress(IpAddress address);
 
+    boolean existsByAddress(IpAddress address);
 }

--- a/src/main/java/com/crosscert/firewall/service/IPService.java
+++ b/src/main/java/com/crosscert/firewall/service/IPService.java
@@ -41,4 +41,8 @@ public class IPService {
     public List<IP> findAll() {
         return ipRepository.findAll();
     }
+
+    public boolean isPresentIp(IpAddress address) {
+        return ipRepository.existsByAddress(address);
+    }
 }

--- a/src/main/java/com/crosscert/firewall/service/MemberService.java
+++ b/src/main/java/com/crosscert/firewall/service/MemberService.java
@@ -3,6 +3,7 @@ package com.crosscert.firewall.service;
 import com.crosscert.firewall.annotation.LogTrace;
 import com.crosscert.firewall.dto.MemberDTO;
 import com.crosscert.firewall.entity.IP;
+import com.crosscert.firewall.entity.IpAddress;
 import com.crosscert.firewall.entity.Member;
 import com.crosscert.firewall.entity.Role;
 import com.crosscert.firewall.repository.MemberRepository;
@@ -30,6 +31,8 @@ public class MemberService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+
+    private final IPService ipService;
 
     public Member save(Member member) {
         return memberRepository.save(member);
@@ -65,6 +68,11 @@ public class MemberService implements UserDetailsService {
         //중복 회원 검증
         if(isPresentMember(memberDTO.getEmail())){
             throw new IllegalArgumentException("이미 존재하는 회원입니다.");
+        }
+
+        //중복 IP주소 검증
+        if (ipService.isPresentIp(new IpAddress(memberDTO.getDevIp())) || ipService.isPresentIp(new IpAddress(memberDTO.getNetIp()))){
+            throw new IllegalArgumentException("이미 존재하는 IP주소 입니다.");
         }
 
         //DTO -> Entity

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -4,7 +4,7 @@ function checkEmail(){
     let email = document.getElementById("email").value;
     if(email){
         $.ajax({
-            url: '/checkDuplicateEmail',
+            url: '/signup/checkDuplicateEmail',
             type: 'GET',
             data: { 'email': email },
             success: function(data) {
@@ -48,7 +48,7 @@ function checkIpAddress(ipType){
         console.log('ipType : '+ipType);
         console.log('ipAddress : '+ipAddress);
         $.ajax({
-            url: '/checkDuplicateIpAddress',
+            url: '/signup/checkDuplicateIpAddress',
             type: 'GET',
             data: { 'ipAddress': ipAddress },
             success: function(data) {

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -1,0 +1,75 @@
+const emailNotOkMsg = document.getElementById("emailNotOkMsg");
+//중복 회원 검증
+function checkEmail(){
+    let email = document.getElementById("email").value;
+    if(email){
+        $.ajax({
+            url: '/checkDuplicateEmail',
+            type: 'GET',
+            data: { 'email': email },
+            success: function(data) {
+                if(data.result === true) {
+                    console.log("중복된 아이디(이메일)")
+                    emailNotOkMsg.style.display = "block";
+                    document.getElementById("email").value = "";
+                    document.getElementById("email").focus();
+                }else {
+                    console.log("사용가능한 아이디(이메일)")
+                    emailNotOkMsg.style.display = "none";
+                }
+            }
+        });
+    }
+}
+
+
+//비밀번호 확인 검증
+const passwordInput = document.getElementById("password");
+const passwordConfirmInput = document.getElementById("passwordConfirm");
+const passwordConfirmError = document.getElementById("passwordConfirmError");
+
+function validatePasswordConfirm() {
+    if (passwordInput.value !== passwordConfirmInput.value) {
+        passwordConfirmInput.classList.add("is-invalid");
+        passwordConfirmError.style.display = "block";
+    } else {
+        passwordConfirmInput.classList.remove("is-invalid");
+        passwordConfirmError.style.display = "none";
+    }
+}
+
+passwordInput.addEventListener("input", validatePasswordConfirm);
+passwordConfirmInput.addEventListener("input", validatePasswordConfirm);
+
+function checkIpAddress(ipType){
+    let ipAddress = document.getElementById(ipType).value;
+    let ipNotOkMsg = document.getElementById(ipType+"NotOkMsg");
+    if(ipAddress){
+        console.log('ipType : '+ipType);
+        console.log('ipAddress : '+ipAddress);
+        $.ajax({
+            url: '/checkDuplicateIpAddress',
+            type: 'GET',
+            data: { 'ipAddress': ipAddress },
+            success: function(data) {
+                if(data.result === true) {
+                    console.log("이미 등록된 IP주소")
+                    ipNotOkMsg.style.display = "block";
+                    document.getElementById(ipType).value = "";
+                    document.getElementById(ipType).focus();
+                }else {
+                    console.log("사용가능한 IP주소")
+                    ipNotOkMsg.style.display = "none";
+                }
+            }
+        });
+
+        if (document.getElementById('devIp').value === document.getElementById('netIp').value){
+            document.getElementById("netIpNotOkMsg").style.display = "block";
+            document.getElementById('netIp').value = "";
+            document.getElementById('netIp').focus();
+        }
+    }
+
+
+}

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -57,7 +57,7 @@
 
                         <div class="col-12">
                             <label for="password" class="form-label">비밀번호</label>
-                            <input type="password" onfocus="checkEmail();" class="form-control" id="password" name="password" required/>
+                            <input type="password" class="form-control" id="password" name="password" required/>
                             <div class="invalid-feedback">
                                 비밀번호를 올바르게 입력하세요.
                             </div>
@@ -83,13 +83,27 @@
                         </div>
 
                         <div class="col-12">
-                            <label for="devIp" class="form-label">개발망 IP주소 <span class="text-muted">(선택)</span></label>
-                            <input type="text" class="form-control" id="devIp" placeholder="예) 172.77.33.11" name="devIp">
+                            <label for="devIp" class="form-label">개발망 IP주소</label>
+                            <input type="text" onfocusout="checkIpAddress('devIp');" class="form-control" id="devIp" placeholder="예) 172.77.33.11" name="devIp"
+                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" required>
+                            <div class="invalid-feedback" >
+                                IP주소를 올바르게 입력하세요.
+                            </div>
+                            <div class="invalid-feedback" id="devIpNotOkMsg" style="display: none;">
+                                중복된 IP주소 입니다.
+                            </div>
                         </div>
 
                         <div class="col-12">
-                            <label for="netIp" class="form-label">인터넷망 IP주소 <span class="text-muted">(선택)</span></label>
-                            <input type="text" class="form-control" id="netIp" placeholder="예) 172.77.33.11" name="netIp">
+                            <label for="netIp" class="form-label">인터넷망 IP주소</label>
+                            <input type="text" onfocusout="checkIpAddress('netIp');" class="form-control" id="netIp" placeholder="예) 172.77.33.11" name="netIp"
+                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" required>
+                            <div class="invalid-feedback">
+                                IP주소를 올바르게 입력하세요.
+                            </div>
+                            <div class="invalid-feedback" id="netIpNotOkMsg" style="display: none;">
+                                중복된 IP주소 혹은 입력하신 개발망 IP주소와 동일합니다.
+                            </div>
                         </div>
 
                         <input type="hidden" name="role" value="MEMBER" readonly/><br>
@@ -109,50 +123,6 @@
 <script src="/js/bootstrap.bundle.min.js"></script>
 <script src="/js/form-validation.js"></script>
 <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
-<script>
-    const emailNotOkMsg = document.getElementById("emailNotOkMsg");
-    //중복 회원 검증
-    function checkEmail(){
-        let email = document.getElementById("email").value;
-        if(email!==null || email!==''){
-            $.ajax({
-                url: '/checkDuplicateEmail',
-                type: 'GET',
-                data: { 'email': email },
-                success: function(data) {
-                    if(data.result === true) {
-                        console.log("중복된 아이디(이메일)")
-                        emailNotOkMsg.style.display = "block";
-                        document.getElementById("email").value = "";
-                        document.getElementById("email").focus();
-                    }else {
-                        console.log("사용가능한 아이디(이메일)")
-                        emailNotOkMsg.style.display = "none";
-                    }
-                }
-            });
-        }
-    }
-
-
-    //비밀번호 확인 검증
-    const passwordInput = document.getElementById("password");
-    const passwordConfirmInput = document.getElementById("passwordConfirm");
-    const passwordConfirmError = document.getElementById("passwordConfirmError");
-
-    function validatePasswordConfirm() {
-        if (passwordInput.value !== passwordConfirmInput.value) {
-            passwordConfirmInput.classList.add("is-invalid");
-            passwordConfirmError.style.display = "block";
-        } else {
-            passwordConfirmInput.classList.remove("is-invalid");
-            passwordConfirmError.style.display = "none";
-        }
-    }
-
-    passwordInput.addEventListener("input", validatePasswordConfirm);
-    passwordConfirmInput.addEventListener("input", validatePasswordConfirm);
-
-</script>
+<script src="/js/signup.js"></script>
 </body>
 </html>

--- a/src/test/java/com/crosscert/firewall/controller/LoginControllerTest.java
+++ b/src/test/java/com/crosscert/firewall/controller/LoginControllerTest.java
@@ -83,5 +83,21 @@ public class LoginControllerTest {
         resultActions.andExpect(jsonPath("result").value("false"));
     }
 
+    @Test
+    @DisplayName("IP_중복_체크")
+    public void IP_중복_체크() throws Exception {
+        ResultActions resultActions = mockMvc.perform(get("/checkDuplicateIpAddress")
+                        .param("ipAddress", "172.77.0.1"))
+                .andExpect(status().is2xxSuccessful());
+
+        resultActions.andExpect(jsonPath("result").value("true"));
+
+        resultActions = mockMvc.perform(get("/checkDuplicateIpAddress")
+                        .param("ipAddress", "172.77.0.3"))
+                .andExpect(status().is2xxSuccessful());
+
+        resultActions.andExpect(jsonPath("result").value("false"));
+    }
+
 
 }

--- a/src/test/java/com/crosscert/firewall/service/IPServiceTest.java
+++ b/src/test/java/com/crosscert/firewall/service/IPServiceTest.java
@@ -1,9 +1,12 @@
 package com.crosscert.firewall.service;
 
+import com.crosscert.firewall.dto.MemberDTO;
 import com.crosscert.firewall.entity.IP;
 import com.crosscert.firewall.entity.IpAddress;
+import com.crosscert.firewall.entity.Role;
 import com.crosscert.firewall.repository.IPRepository;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @SpringBootTest
@@ -23,6 +28,11 @@ class IPServiceTest {
 
     @Autowired
     IPService ipService;
+
+    @BeforeEach
+    void clean(){
+        ipRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("findByAddress Exception")
@@ -40,5 +50,26 @@ class IPServiceTest {
             ipService.findById(2L);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("해당 IP가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("isPresentIp Test")
+    void isPresentIp() {
+        // Given
+        IP ip = IP.builder()
+                .domain("testdomain.com")
+                .description("테스트 IP")
+                .address(new IpAddress("172.77.0.1"))
+                .build();
+        ipService.save(ip);
+
+
+        // When
+        String ip1 =  "172.77.0.3";
+        String ip2 = "172.77.0.1";   //IP 중복
+
+        // Then
+        assertFalse(ipService.isPresentIp(new IpAddress(ip1)));
+        assertTrue(ipService.isPresentIp(new IpAddress(ip2)));  //IP 중복시 true
     }
 }


### PR DESCRIPTION
resolved: #53  
**회원가입**
-  IP주소 필수 사항으로 변경 (+유효성검사)
-  IP주소 중복검사 후 가입 진행 (입력시 비동기 + 가입 요청시)
-  회원가입 자바스크립트 분리
-  테스트코드
- 운영(prod) 환경에서 회원가입 시 비동기식 이메일중복검사, IP중복검사 안되는 이슈 해결