### PR TITLE
회원 수정 - IP신규 등록 혹은 미사용IP만 할당 자동 진행

### DIFF
--- a/src/main/java/com/crosscert/firewall/controller/LoginController.java
+++ b/src/main/java/com/crosscert/firewall/controller/LoginController.java
@@ -8,10 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,10 +37,11 @@ public class LoginController {
 
     //회원가입 진행
     @PostMapping("/signup")
-    public String signup(MemberDTO.Request.Create memberDTO){
+    public String signup(MemberDTO.Request.Create memberDTO, Model model){
         log.info("{}.signup",this.getClass());
         memberService.signup(memberDTO);
-        return "redirect:/login";
+        model.addAttribute("signupSuccess", "회원가입 성공!");
+        return "login";
     }
 
 

--- a/src/main/java/com/crosscert/firewall/controller/MemberController.java
+++ b/src/main/java/com/crosscert/firewall/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.crosscert.firewall.dto.MemberDTO;
 import com.crosscert.firewall.entity.Ip;
 import com.crosscert.firewall.entity.IpAddress;
 import com.crosscert.firewall.entity.Member;
+import com.crosscert.firewall.entity.Role;
 import com.crosscert.firewall.service.IpService;
 import com.crosscert.firewall.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -38,13 +39,16 @@ public class MemberController {
         Member member = memberService.findById(id);
         MemberDTO.Response.Public memberDto = convertToPublicDto(member);
 
-        List<Ip> ipList = ipService.findAllWithoutMember();
-        List<String> addresses = ipList.stream()
-                .map(Ip::getAddressValue)
-                .collect(Collectors.toList());
+//        List<Ip> ipList = ipService.findAllWithoutMember();
+//        List<String> addresses = ipList.stream()
+//                .map(Ip::getAddressValue)
+//                .collect(Collectors.toList());
 
+
+
+        model.addAttribute("roles", Role.values());
         model.addAttribute("member", memberDto);
-        model.addAttribute("addresses", addresses);
+//        model.addAttribute("addresses", addresses);
         return "memberEdit";
     }
 

--- a/src/main/java/com/crosscert/firewall/controller/api/MemberApiController.java
+++ b/src/main/java/com/crosscert/firewall/controller/api/MemberApiController.java
@@ -38,8 +38,23 @@ public class MemberApiController {
     public ResponseEntity<MemberDTO.Response.Edit> edit(@PathVariable("id") Long id, @RequestBody MemberDTO.Request.Edit memberDTO) {
         Member findMember = memberService.findById(id);
 
-        Ip devIp = ipService.findByAddress(new IpAddress(memberDTO.getDevIp()));
-        Ip netIp = ipService.findByAddress(new IpAddress(memberDTO.getNetIp()));
+        Ip devIp;
+        Ip netIp;
+
+        //개발망IP
+        if(memberDTO.getDevIp().equals(findMember.getDevIpValue())){
+            devIp = findMember.getDevIp();
+        }else {
+            devIp = ipService.allocateIp(memberDTO.getDevIp(),findMember.getName()+" 개발망");
+            findMember.getDevIp().editDescription(null);
+        }
+        //인터넷망IP
+        if(memberDTO.getNetIp().equals(findMember.getNetIpValue())){
+            netIp = findMember.getNetIp();
+        }else {
+            netIp = ipService.allocateIp(memberDTO.getNetIp(),findMember.getName()+" 인터넷망");
+            findMember.getNetIp().editDescription(null);
+        }
 
         memberService.edit(findMember, memberDTO.getRole(), devIp, netIp);
         MemberDTO.Response.Edit resultDto = convertToEditDto(findMember);
@@ -60,6 +75,7 @@ public class MemberApiController {
     private MemberDTO.Response.Edit convertToEditDto(Member member){
         return new MemberDTO.Response.Edit(
                 member.getId(),
+                member.getName(),
                 member.getRole(),
                 member.getDevIpValue(),
                 member.getNetIpValue()

--- a/src/main/java/com/crosscert/firewall/dto/MemberDTO.java
+++ b/src/main/java/com/crosscert/firewall/dto/MemberDTO.java
@@ -20,13 +20,12 @@ public enum MemberDTO {;
         @NoArgsConstructor
         @AllArgsConstructor
         @Getter
-        public static class Create implements Name, Email, Password, MemberRole, DevIp, NetIp{
+        @Setter
+        public static class Create implements Name, Email, Password, MemberRole{
              String name;
              String email;
              String password;
              Role role;
-             String devIp;
-             String netIp;
         }
 
         @NoArgsConstructor
@@ -62,8 +61,9 @@ public enum MemberDTO {;
         @NoArgsConstructor
         @AllArgsConstructor
         @Getter
-        public static class Edit implements Id, MemberRole, DevIp, NetIp {
+        public static class Edit implements Id, Name, MemberRole, DevIp, NetIp {
             Long id;
+            String name;
             Role role;
             String devIp;
             String netIp;

--- a/src/main/java/com/crosscert/firewall/entity/Ip.java
+++ b/src/main/java/com/crosscert/firewall/entity/Ip.java
@@ -49,9 +49,9 @@ public class Ip extends BaseTimeEntity{
         this.netMember = netMember;
     }
 
-    public void memberUpdate(Member member) {
-        this.devMember = member;
-        this.netMember = member;
+
+    public void editDescription(String description){
+        this.description = description;
     }
 
 

--- a/src/main/java/com/crosscert/firewall/service/IpService.java
+++ b/src/main/java/com/crosscert/firewall/service/IpService.java
@@ -43,4 +43,24 @@ public class IpService {
     public boolean isPresentIp(IpAddress address) {
         return ipRepository.existsByAddress(address);
     }
+
+    //DB에 없으면 신규 IP 생성 / 있으면 다른 회원이 미사용중일때만 가능
+    public Ip allocateIp(String address, String description){
+        IpAddress ipAddress = new IpAddress(address);
+
+        //DB에 없을 경우 신규 생성
+        if(!isPresentIp(ipAddress)) {
+            return new Ip(address,description);
+        }
+
+        //DB에 있을 경우 다른 회원이 미사용중일때만 가능
+        Ip findIp = findByAddress(ipAddress);
+        if(findIp.getDevMember() == null && findIp.getNetMember() == null){
+            findIp.editDescription(description);
+            return findIp;
+        }else{
+            throw new IllegalArgumentException("해당 IP는 다른 이용자가 사용중입니다.");
+        }
+
+    }
 }

--- a/src/main/java/com/crosscert/firewall/service/LoginService.java
+++ b/src/main/java/com/crosscert/firewall/service/LoginService.java
@@ -1,0 +1,44 @@
+package com.crosscert.firewall.service;
+
+import com.crosscert.firewall.annotation.LogTrace;
+import com.crosscert.firewall.dto.MemberDTO;
+import com.crosscert.firewall.entity.Ip;
+import com.crosscert.firewall.entity.Member;
+import com.crosscert.firewall.entity.Role;
+import com.crosscert.firewall.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Log4j2
+public class LoginService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    //스프링시큐리티 로그인
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException("없는 회원 정보 입니다."));
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().name()));
+        return new User(member.getEmail(), member.getPassword(), authorities);
+    }
+}
+
+
+
+

--- a/src/main/java/com/crosscert/firewall/service/MemberService.java
+++ b/src/main/java/com/crosscert/firewall/service/MemberService.java
@@ -68,10 +68,10 @@ public class MemberService implements UserDetailsService {
             throw new IllegalArgumentException("이미 존재하는 회원입니다.");
         }
 
-        //중복 IP주소 검증
-        if (ipService.isPresentIp(new IpAddress(memberDTO.getDevIp())) || ipService.isPresentIp(new IpAddress(memberDTO.getNetIp()))){
-            throw new IllegalArgumentException("이미 존재하는 IP주소 입니다.");
-        }
+//        //중복 IP주소 검증
+//        if (ipService.isPresentIp(new IpAddress(memberDTO.getDevIp())) || ipService.isPresentIp(new IpAddress(memberDTO.getNetIp()))){
+//            throw new IllegalArgumentException("이미 존재하는 IP주소 입니다.");
+//        }
 
         //DTO -> Entity
         Member member = Member.builder()
@@ -80,8 +80,8 @@ public class MemberService implements UserDetailsService {
                 .password(passwordEncoder.encode(memberDTO.getPassword()))
                 .role(memberDTO.getRole()).build();
 
-        member.setDevIpByAddress(memberDTO.getDevIp(), memberDTO.getName());
-        member.setNetIpByAddress(memberDTO.getNetIp(), memberDTO.getName());
+//        member.setDevIpByAddress(memberDTO.getDevIp(), memberDTO.getName());
+//        member.setNetIpByAddress(memberDTO.getNetIp(), memberDTO.getName());
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/crosscert/firewall/service/MemberService.java
+++ b/src/main/java/com/crosscert/firewall/service/MemberService.java
@@ -26,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 @Log4j2
-public class MemberService implements UserDetailsService {
+public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -68,11 +68,6 @@ public class MemberService implements UserDetailsService {
             throw new IllegalArgumentException("이미 존재하는 회원입니다.");
         }
 
-//        //중복 IP주소 검증
-//        if (ipService.isPresentIp(new IpAddress(memberDTO.getDevIp())) || ipService.isPresentIp(new IpAddress(memberDTO.getNetIp()))){
-//            throw new IllegalArgumentException("이미 존재하는 IP주소 입니다.");
-//        }
-
         //DTO -> Entity
         Member member = Member.builder()
                 .name(memberDTO.getName())
@@ -84,16 +79,6 @@ public class MemberService implements UserDetailsService {
 //        member.setNetIpByAddress(memberDTO.getNetIp(), memberDTO.getName());
         memberRepository.save(member);
     }
-
-    //스프링시큐리티 로그인
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException("없는 회원 정보 입니다."));
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority(member.getRole().name()));
-        return new User(member.getEmail(), member.getPassword(), authorities);
-    }
-
 
     public void deleteByEmail(String email) {
         memberRepository.deleteByEmail(email);

--- a/src/main/resources/static/js/member.js
+++ b/src/main/resources/static/js/member.js
@@ -1,15 +1,43 @@
-let divMenu = document.querySelector(".ip-menu-div");
-let netMenu = document.querySelector(".ip-menu-net");
+let id = memberId;
+const form = document.getElementById("edit-form");
+form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const role = document.getElementById("role");
+    const devIp = document.getElementById("devIp").value;
+    const netIp = document.getElementById("netIp").value;
+    if (devIp === netIp) {
+        alert("개발망 IP주소와 인터넷망 IP주소가 동일합니다.");
+        return;
+    }
+    if (form.checkValidity()) {
+        const url = '/api/member/' + id;
+        const data = {
+            role: role.value,
+            devIp: devIp,
+            netIp: netIp
+        };
 
-function divIpClick(e) {
-    document.querySelector(".devIp").value = e.target.innerText;
-    document.querySelector(".devBtn").innerText = e.target.innerText;
-}
-
-function netIpClick(e) {
-    document.querySelector(".netIp").value = e.target.innerText;
-    document.querySelector(".netBtn").innerText = e.target.innerText;
-}
-
-divMenu.addEventListener("click",divIpClick)
-netMenu.addEventListener("click",netIpClick)
+        fetch(url, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json; charset=utf-8"
+            },
+            body: JSON.stringify(data)
+        }).then(response => {
+            if (response.ok) {
+                return response.json();
+            } else {
+                alert("회원 수정 실패")
+            }
+        }).then(data => {
+                alert(data.name +" 회원 수정 성공");
+                location.href = '/members';
+            }).catch(error => {
+            alert(error);
+        });
+        
+    } else {
+        event.stopPropagation();
+        form.classList.add("was-validated");
+    }
+});

--- a/src/main/resources/static/js/signup.js
+++ b/src/main/resources/static/js/signup.js
@@ -41,35 +41,37 @@ function validatePasswordConfirm() {
 passwordInput.addEventListener("input", validatePasswordConfirm);
 passwordConfirmInput.addEventListener("input", validatePasswordConfirm);
 
-function checkIpAddress(ipType){
-    let ipAddress = document.getElementById(ipType).value;
-    let ipNotOkMsg = document.getElementById(ipType+"NotOkMsg");
-    if(ipAddress){
-        console.log('ipType : '+ipType);
-        console.log('ipAddress : '+ipAddress);
-        $.ajax({
-            url: '/signup/checkDuplicateIpAddress',
-            type: 'GET',
-            data: { 'ipAddress': ipAddress },
-            success: function(data) {
-                if(data.result === true) {
-                    console.log("이미 등록된 IP주소")
-                    ipNotOkMsg.style.display = "block";
-                    document.getElementById(ipType).value = "";
-                    document.getElementById(ipType).focus();
-                }else {
-                    console.log("사용가능한 IP주소")
-                    ipNotOkMsg.style.display = "none";
-                }
-            }
-        });
 
-        if (document.getElementById('devIp').value === document.getElementById('netIp').value){
-            document.getElementById("netIpNotOkMsg").style.display = "block";
-            document.getElementById('netIp').value = "";
-            document.getElementById('netIp').focus();
-        }
-    }
-
-
-}
+//
+// function checkIpAddress(ipType){
+//     let ipAddress = document.getElementById(ipType).value;
+//     let ipNotOkMsg = document.getElementById(ipType+"NotOkMsg");
+//     if(ipAddress){
+//         console.log('ipType : '+ipType);
+//         console.log('ipAddress : '+ipAddress);
+//         $.ajax({
+//             url: '/signup/checkDuplicateIpAddress',
+//             type: 'GET',
+//             data: { 'ipAddress': ipAddress },
+//             success: function(data) {
+//                 if(data.result === true) {
+//                     console.log("이미 등록된 IP주소")
+//                     ipNotOkMsg.style.display = "block";
+//                     document.getElementById(ipType).value = "";
+//                     document.getElementById(ipType).focus();
+//                 }else {
+//                     console.log("사용가능한 IP주소")
+//                     ipNotOkMsg.style.display = "none";
+//                 }
+//             }
+//         });
+//
+//         if (document.getElementById('devIp').value === document.getElementById('netIp').value){
+//             document.getElementById("netIpNotOkMsg").style.display = "block";
+//             document.getElementById('netIp').value = "";
+//             document.getElementById('netIp').focus();
+//         }
+//     }
+//
+//
+// }

--- a/src/main/resources/templates/layouts/layout.html
+++ b/src/main/resources/templates/layouts/layout.html
@@ -11,6 +11,15 @@
   <link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" />
   <link href="/css/styles.css" rel="stylesheet" />
   <script src="https://use.fontawesome.com/releases/v6.1.0/js/all.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+  <script src="/js/scripts.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js" crossorigin="anonymous"></script>
+  <script src="/assets/demo/chart-area-demo.js"></script>
+  <script src="/assets/demo/chart-bar-demo.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" crossorigin="anonymous"></script>
+  <script src="/js/datatables-simple-demo.js"></script>
+
+
 </head>
 <body class="sb-nav-fixed">
 <nav th:replace="fragments/nav :: navigation">
@@ -25,12 +34,6 @@
     </footer>
   </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-<script src="/js/scripts.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js" crossorigin="anonymous"></script>
-<script src="/assets/demo/chart-area-demo.js"></script>
-<script src="/assets/demo/chart-bar-demo.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest" crossorigin="anonymous"></script>
-<script src="/js/datatables-simple-demo.js"></script>
+
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -39,6 +39,11 @@
                                         </form>
                                     </div>
                                     <div class="card-footer text-center py-3">
+                                        <!-- alert 창 -->
+                                        <div th:if="${signupSuccess}" class="alert alert-success alert-dismissible fade show" role="alert">
+                                            <span th:text="${signupSuccess}"></span>
+                                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                                        </div>
                                         <div class="small"><a th:href="@{/signup}">회원가입</a></div>
                                     </div>
                                 </div>

--- a/src/main/resources/templates/memberEdit.html
+++ b/src/main/resources/templates/memberEdit.html
@@ -23,54 +23,63 @@
         </div>
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fas fa-table me-1"></i>
+                <i class="bi bi-person-circle"></i>
                 계정 수정
             </div>
             <div class="card-body">
-                <form th:action="@{/member/{id}(id=${member.id})}" th:object="${member}" th:method="PUT">
-                    <div>
-                        <label for="name">이름</label>
-                        <input type="text" id=name th:field="*{name}">
-                    </div>
-                    <div>
-                        <label for="email">이메일</label>
-                        <input type="email" id=email th:field="*{email}">
-                    </div>
-                    <div>
-                        <label for="role">Role</label>
-                        <input type="text" id=role th:field="*{role}">
-                    </div>
-                    <div>
-                        <label for="devIp">개발망 Ip</label>
-                        <div class="dropdown ip-div">
-                            <input type="text" class="devIp" id=devIp style="display: none">
-                            <button class="btn btn-outline-primary dropdown-toggle devBtn" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
-                                IP List
-                            </button>
-                            <ul class="dropdown-menu ip-menu-div" aria-labelledby="dropdownMenuButton1" >
-                                <li class="dropdown-item" th:each="address : ${addresses}" th:text="${address}"></li>
-                            </ul>
+<!--                <form class="needs-validation" novalidate th:object="${member}" th:action="@{/api/v1/member/{id}(id=${member.id})}">-->
+                <form id="edit-form" class="needs-validation" novalidate th:object="${member}">
+                    <div class="row g-3">
+                        <div class="col-12">
+                            <label for="email" class="form-label">아이디(이메일)</label>
+                            <input type="email" class="form-control" id="email" name="email" th:field="*{email}" readonly>
+                        </div>
+
+                        <div class="col-12">
+                            <label for="name" class="form-label">이름</label>
+                            <input type="text" class="form-control" id="name" name="name" th:field="*{name}" readonly>
+                        </div>
+
+                        <div class="col-12">
+                            <label for="name" class="form-label">권한(ROLE)</label>
+                            <select th:field="*{role}" class="form-select">
+                                <option th:each="role : ${roles}" th:value="${role}" th:text="${role}" id=role name="role"></option>
+                            </select>
+                        </div>
+
+                        <div class="col-12">
+                            <label for="devIp" class="form-label">개발망 IP주소</label>
+                            <input type="text" class="form-control" id="devIp" placeholder="예) 172.77.33.11" name="devIp"
+                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" th:field="*{devIp}" required>
+                            <div class="invalid-feedback" >
+                                IP주소를 올바르게 입력하세요.
+                            </div>
+                        </div>
+
+                        <div class="col-12">
+                            <label for="netIp" class="form-label">인터넷망 IP주소</label>
+                            <input type="text" class="form-control" id="netIp" placeholder="예) 172.77.33.11" name="netIp"
+                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" th:field="*{netIp}" required>
+                            <div class="invalid-feedback">
+                                IP주소를 올바르게 입력하세요.
+                            </div>
                         </div>
                     </div>
-                    <div>
-                        <label for="netIp">인터넷망 Ip</label>
-                        <div class="dropdown ip-div">
-                            <input type="text" class="netIp" id=netIp style="display: none">
-                            <button class="btn btn-outline-primary dropdown-toggle netBtn" type="button" id="dropdownMenuButton2" data-bs-toggle="dropdown" aria-expanded="false">
-                                IP List
-                            </button>
-                            <ul class="dropdown-menu ip-menu-net" aria-labelledby="dropdownMenuButton1" >
-                                <li class="dropdown-item" th:each="address : ${addresses}" th:text="${address}"></li>
-                            </ul>
-                        </div>
-                    </div>
-                    <button type="submit" class="btn btn-primary">정보 수정</button>
+
+                    <hr class="my-4">
+
+                    <button class="w-100 btn btn-primary btn-lg" type="submit">수정하기</button>
                 </form>
             </div>
         </div>
     </div>
+    <script th:inline="javascript">
+        const memberId = [[${member.id}]];
+    </script>
+    <script src="/js/member.js"></script>
+    <script src="https://code.jquery.com/jquery-3.4.1.js"></script>
+    <script src="/js/form-validation.js"></script>
+    <script src="/js/bootstrap.bundle.min.js"></script> <!--TODO: 이거를 레이아웃에 넣으면 메뉴바 사람아이콘이 무반응이다. -->
 </main>
-<script src="/js/bootstrap.bundle.min.js"> </script>
-<script src="/js/member.js"> </script>
 </body>
 </html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -82,32 +82,7 @@
                             </div>
                         </div>
 
-                        <div class="col-12">
-                            <label for="devIp" class="form-label">개발망 IP주소</label>
-                            <input type="text" onfocusout="checkIpAddress('devIp');" class="form-control" id="devIp" placeholder="예) 172.77.33.11" name="devIp"
-                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" required>
-                            <div class="invalid-feedback" >
-                                IP주소를 올바르게 입력하세요.
-                            </div>
-                            <div class="invalid-feedback" id="devIpNotOkMsg" style="display: none;">
-                                중복된 IP주소 입니다.
-                            </div>
-                        </div>
-
-                        <div class="col-12">
-                            <label for="netIp" class="form-label">인터넷망 IP주소</label>
-                            <input type="text" onfocusout="checkIpAddress('netIp');" class="form-control" id="netIp" placeholder="예) 172.77.33.11" name="netIp"
-                                   pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$" required>
-                            <div class="invalid-feedback">
-                                IP주소를 올바르게 입력하세요.
-                            </div>
-                            <div class="invalid-feedback" id="netIpNotOkMsg" style="display: none;">
-                                중복된 IP주소 혹은 입력하신 개발망 IP주소와 동일합니다.
-                            </div>
-                        </div>
-
                         <input type="hidden" name="role" value="MEMBER" readonly/><br>
-
                     </div>
 
                     <hr class="my-4">

--- a/src/test/java/com/crosscert/firewall/controller/LoginControllerTest.java
+++ b/src/test/java/com/crosscert/firewall/controller/LoginControllerTest.java
@@ -2,8 +2,11 @@ package com.crosscert.firewall.controller;
 
 import com.crosscert.firewall.config.DatabaseCleanup;
 import com.crosscert.firewall.dto.MemberDTO;
+import com.crosscert.firewall.entity.Ip;
+import com.crosscert.firewall.entity.IpAddress;
 import com.crosscert.firewall.entity.Role;
 import com.crosscert.firewall.repository.MemberRepository;
+import com.crosscert.firewall.service.IpService;
 import com.crosscert.firewall.service.MemberService;
 import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +33,9 @@ public class LoginControllerTest {
 
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private IpService ipService;
+
 
     @Autowired
     private DatabaseCleanup databaseCleanup;
@@ -40,7 +46,7 @@ public class LoginControllerTest {
         databaseCleanup.execute();
 
         MemberDTO.Request.Create createDto = new MemberDTO.Request.Create(
-                "test", "test@crosscert.com", "password", Role.MEMBER, "172.77.0.1", "172.77.0.2");
+                "test", "test@crosscert.com", "password", Role.MEMBER);
         memberService.signup(createDto);
     }
 
@@ -82,6 +88,12 @@ public class LoginControllerTest {
     @Test
     @DisplayName("IP_중복_체크")
     public void IP_중복_체크() throws Exception {
+
+        //when
+        Ip ip = new Ip("172.77.0.1","description");
+        ipService.save(ip);
+
+
         ResultActions resultActions = mockMvc.perform(get("/signup/checkDuplicateIpAddress")
                         .param("ipAddress", "172.77.0.1"))
                 .andExpect(status().is2xxSuccessful());

--- a/src/test/java/com/crosscert/firewall/service/MemberServiceTest.java
+++ b/src/test/java/com/crosscert/firewall/service/MemberServiceTest.java
@@ -137,7 +137,7 @@ class MemberServiceTest {
     public void 정상적인_회원가입() {
         //given
         MemberDTO.Request.Create createDto = new MemberDTO.Request.Create(
-                "test", "test@crosscert.com", "password", Role.MEMBER, "172.77.0.1", "172.77.0.2");
+                "test", "test@crosscert.com", "password", Role.MEMBER);
 
         //when
         memberService.signup(createDto);
@@ -146,8 +146,6 @@ class MemberServiceTest {
         Member findMember = memberRepository.findByEmail(createDto.getEmail()).orElseThrow(() -> new IllegalStateException("회원정보 없음"));
         assertEquals(createDto.getName(), findMember.getName());
         assertTrue(passwordEncoder.matches(createDto.getPassword(), findMember.getPassword()));
-        assertEquals(createDto.getDevIp(), findMember.getDevIp().getAddress().getAddress());
-        assertEquals(createDto.getNetIp(), findMember.getNetIp().getAddress().getAddress());
         assertEquals(createDto.getRole(), findMember.getRole());
     }
 
@@ -155,12 +153,12 @@ class MemberServiceTest {
     public void 중복회원가입시_IllegalStateException() {
         //given
         MemberDTO.Request.Create createDto = new MemberDTO.Request.Create(
-                "test2", "test2@crosscert.com", "password", Role.MEMBER, "172.77.0.1", "172.77.0.2");
+                "test2", "test2@crosscert.com", "password", Role.MEMBER);
 
         memberService.signup(createDto);
 
         MemberDTO.Request.Create createDto2 = new MemberDTO.Request.Create(
-                "test3", "test2@crosscert.com", "password3", Role.MEMBER, "172.77.0.3", "172.77.0.4");
+                "test3", "test2@crosscert.com", "password3", Role.MEMBER);
 
         //when & then
         assertThatThrownBy(() -> memberService.signup(createDto))
@@ -174,7 +172,7 @@ class MemberServiceTest {
         // Given
         MemberDTO.Request.Create createDto =
                 new MemberDTO.Request.Create(
-                        "test4", "test4@crosscert.com", "password3", Role.MEMBER, "172.77.0.1", "172.77.0.2");
+                        "test4", "test4@crosscert.com", "password3", Role.MEMBER);
 
         memberService.signup(createDto);
 


### PR DESCRIPTION
resolved: #62 
**회원 수정**
- 회원 수정 시 IP 선택 -> IP 입력으로 변경
- 백단에서 IP신규 등록 혹은 할당 자동 진행 (현재값 제외)
- 회원 가입시 IP 입력하지 않는 것으로 변경
- 로그인 메서드 LoginService로 이동
- 테스트 코드 작성